### PR TITLE
Tree watcher should bail out completely after too many init failures

### DIFF
--- a/src/treeWatcher.js
+++ b/src/treeWatcher.js
@@ -9,6 +9,7 @@ const wsUrlPool = wsRpcUrl.split(',')
 const PoofBaseABI = require('../abis/poofBase.abi.json')
 
 let wsIdx = 0
+let failedInitRetries = 0
 let web3
 
 const trees = {}
@@ -170,6 +171,10 @@ const getInit = treeAddress => {
       await updateRedis(contract)
     } catch (e) {
       console.error('error on init treeWatcher', e.message)
+      if (failedInitRetries++ > 3) {
+        console.error('init failed too many times')
+        process.exit(1)
+      }
       setTimeout(init, 3000)
     }
   }


### PR DESCRIPTION
Tree watcher can get stuck in a bad state and the only recourse is to have docker restart the process.
Tally up the failed inits and if we failed more than 3 times already, exit the process and let docker restart the entire treewatcher from scratch